### PR TITLE
correct comparison of segments to filename

### DIFF
--- a/munin/plugins/hls-rtmp-live-viewer
+++ b/munin/plugins/hls-rtmp-live-viewer
@@ -224,7 +224,7 @@ def count_hls_viewers():
 
 			# test the filename against all fragement-filenames we're intérested in
 			for stream, segment in interesting_segments.iteritems():
-				if segment == filename:
+				if os.path.basename(segment) == filename:
 					# and count one up for that stream
 					viewer_counts[filebasename(stream)] += 1
 


### PR DESCRIPTION
As filename is only the basename, segments should 
be too. Critical if hls_base_url is set.
